### PR TITLE
Replace perlapp build scripts with PAR::Packer

### DIFF
--- a/src/build/compile-tk.bat
+++ b/src/build/compile-tk.bat
@@ -1,4 +1,11 @@
 cd ..\..
 set BUILDING_WX=2
-perlapp --clean --trim Pod::Usage;I18N::Langinfo;XSTools --icon src\build\openkore.ico --lib src --norunlib --nologo --force --exe tkstart.exe start.pl --add List::Util;File::Path;Text::Balanced;Digest::MD5;Math::BigInt;Math::BigInt::Calc;Math::BigInt::CalcEmu;Math::BigInt::FastCalc;Math::BigInt::Trace;Math::BigFloat;Math::BigFloat::Trace;Math::BigRat;Math::Complex;Math::Trig;Tk;Tk::**;Win32::API;
+REM Build tkstart.exe with PAR::Packer
+pp --icon src\build\openkore.ico -I src -o tkstart.exe start.pl \
+   -M Pod::Usage -M I18N::Langinfo -M XSTools \
+   -M List::Util -M File::Path -M Text::Balanced -M Digest::MD5 \
+   -M Math::BigInt -M Math::BigInt::Calc -M Math::BigInt::CalcEmu \
+   -M Math::BigInt::FastCalc -M Math::BigInt::Trace -M Math::BigFloat \
+   -M Math::BigFloat::Trace -M Math::BigRat -M Math::Complex -M Math::Trig \
+   -M Tk -M "Tk::*" -M Win32::API
 pause

--- a/src/build/compile-vx.bat
+++ b/src/build/compile-vx.bat
@@ -1,4 +1,11 @@
 cd ..\..
 set BUILDING_WX=2
-perlapp --clean --trim Pod::Usage;I18N::Langinfo;XSTools --icon src\build\openkore.ico --lib src --norunlib --gui --nologo --force --exe vxstart.exe start.pl --add List::Util;File::Path;Text::Balanced;Digest::MD5;Math::BigInt;Math::BigInt::Calc;Math::BigInt::CalcEmu;Math::BigInt::FastCalc;Math::BigInt::Trace;Math::BigFloat;Math::BigFloat::Trace;Math::BigRat;Math::Complex;Math::Trig;Tk;Tk::**;
+REM Build vxstart.exe with PAR::Packer
+pp --gui --icon src\build\openkore.ico -I src -o vxstart.exe start.pl \
+   -M Pod::Usage -M I18N::Langinfo -M XSTools \
+   -M List::Util -M File::Path -M Text::Balanced -M Digest::MD5 \
+   -M Math::BigInt -M Math::BigInt::Calc -M Math::BigInt::CalcEmu \
+   -M Math::BigInt::FastCalc -M Math::BigInt::Trace -M Math::BigFloat \
+   -M Math::BigFloat::Trace -M Math::BigRat -M Math::Complex -M Math::Trig \
+   -M Tk -M "Tk::*"
 pause

--- a/src/build/compile-wingui.bat
+++ b/src/build/compile-wingui.bat
@@ -1,4 +1,11 @@
 cd ..\..
 set BUILDING_WX=3
-perlapp --clean --trim Pod::Usage;I18N::Langinfo;XSTools --icon src\build\openkore.ico --lib src --norunlib --gui --nologo --force --exe winguistart.exe start.pl --add List::Util;File::Path;Text::Balanced;Digest::MD5;Math::BigInt;Math::BigInt::Calc;Math::BigInt::CalcEmu;Math::BigInt::FastCalc;Math::BigInt::Trace;Math::BigFloat;Math::BigFloat::Trace;Math::BigRat;Math::Complex;Math::Trig;Win32::GUI;Win32::GUI;Win32::GUI::Constants;Win32::GUI::**;
+REM Build winguistart.exe with PAR::Packer
+pp --gui --icon src\build\openkore.ico -I src -o winguistart.exe start.pl \
+   -M Pod::Usage -M I18N::Langinfo -M XSTools \
+   -M List::Util -M File::Path -M Text::Balanced -M Digest::MD5 \
+   -M Math::BigInt -M Math::BigInt::Calc -M Math::BigInt::CalcEmu \
+   -M Math::BigInt::FastCalc -M Math::BigInt::Trace -M Math::BigFloat \
+   -M Math::BigFloat::Trace -M Math::BigRat -M Math::Complex -M Math::Trig \
+   -M Win32::GUI -M Win32::GUI::Constants -M "Win32::GUI::*"
 pause

--- a/src/build/compile-wx.bat
+++ b/src/build/compile-wx.bat
@@ -1,4 +1,11 @@
 cd ..\..
 set BUILDING_WX=1
-perlapp --clean --trim Pod::Usage;I18N::Langinfo;Wx::build::**;XSTools --icon src\build\openkore.ico --lib src --norunlib --nologo --force --exe wxstart.exe start.pl --add List::Util;File::Path;Text::Balanced;Digest::MD5;Math::BigInt;Math::BigInt::Calc;Math::BigInt::CalcEmu;Math::BigInt::FastCalc;Math::BigInt::Trace;Math::BigFloat;Math::BigFloat::Trace;Math::BigRat;Math::Complex;Math::Trig;Wx::Perl::Packager;Wx;Wx::**;
+REM Build wxstart.exe with PAR::Packer
+pp --icon src\build\openkore.ico -I src -o wxstart.exe start.pl \
+   -M Pod::Usage -M I18N::Langinfo -M "Wx::build::*" -M XSTools \
+   -M List::Util -M File::Path -M Text::Balanced -M Digest::MD5 \
+   -M Math::BigInt -M Math::BigInt::Calc -M Math::BigInt::CalcEmu \
+   -M Math::BigInt::FastCalc -M Math::BigInt::Trace -M Math::BigFloat \
+   -M Math::BigFloat::Trace -M Math::BigRat -M Math::Complex -M Math::Trig \
+   -M Wx::Perl::Packager -M Wx -M "Wx::*"
 pause

--- a/src/build/compile.bat
+++ b/src/build/compile.bat
@@ -1,3 +1,9 @@
 cd ..\..
-perlapp --trim Pod::Usage;I18N::Langinfo;Wx;Wx::**;XSTools --icon src\build\openkore.ico --lib src --norunlib --nologo --force --exe start.exe start.pl --add List::Util;File::Path;Text::Balanced;Digest::MD5;Math::BigInt;Math::BigInt::Calc;Math::BigInt::CalcEmu;Math::BigInt::FastCalc;Math::BigInt::Trace;Math::BigFloat;Math::BigFloat::Trace;Math::BigRat;Math::Complex;Math::Trig;
+REM Build start.exe using PAR::Packer (pp) instead of the discontinued PerlApp
+pp --icon src\build\openkore.ico -I src -o start.exe start.pl \
+   -M Pod::Usage -M I18N::Langinfo -M Wx -M "Wx::*" -M XSTools \
+   -M List::Util -M File::Path -M Text::Balanced -M Digest::MD5 \
+   -M Math::BigInt -M Math::BigInt::Calc -M Math::BigInt::CalcEmu \
+   -M Math::BigInt::FastCalc -M Math::BigInt::Trace -M Math::BigFloat \
+   -M Math::BigFloat::Trace -M Math::BigRat -M Math::Complex -M Math::Trig
 pause

--- a/start.pl
+++ b/start.pl
@@ -1,6 +1,9 @@
 #!/usr/bin/env perl
 # Win32 Perl script launcher
-# This file is meant to be compiled by PerlApp. It acts like a mini-Perl interpreter.
+# This file is meant to be compiled into a standalone executable.
+# It originally targeted PerlApp from the discontinued ActiveState PDK,
+# but can also be packed with PAR::Packer's `pp` tool. It acts like a
+# mini-Perl interpreter.
 #
 # Your script's initialization and main loop code should be placed in a function
 # called __start() in the main package. That function will be called by this
@@ -39,14 +42,14 @@ use strict;
 use Config;
 
 if ($^O ne 'MSWin32') {
-	# We are not on Windows, so tell the user about it
-	print "\nThis file is meant to be compiled by PerlApp.\n";
-	print "To run kore, execute openkore.pl instead.\n\n";
-	exit 1;
+       # We are not on Windows, so tell the user about it
+       print "\nThis file is meant to be compiled into an executable.\n";
+       print "To run kore, execute openkore.pl instead.\n\n";
+       exit 1;
 }
 
 
-# PerlApp 6's @INC doesn't contain '.', so add it
+# Some packagers may not include '.' in \@INC, so add it explicitly
 my $hasCurrentDir;
 foreach (@INC) {
 	if ($_ eq ".") {
@@ -57,7 +60,7 @@ foreach (@INC) {
 push @INC, "." if (!$hasCurrentDir);
 
 if (0) {
-	# Force PerlApp to include the following modules
+       # Force packagers (PerlApp/pp) to include the following modules
 	use FindBin;
 	require base;
 	require bytes;
@@ -106,28 +109,45 @@ if (0) {
 
 
 if ($PerlApp::TOOL eq "PerlApp") {
-	$ENV{INTERPRETER} = PerlApp::exe();
-	if (PerlApp::exe() =~ /wxstart\.exe$/i) {
-		$ENV{OPENKORE_DEFAULT_INTERFACE} = 'Wx';
-	}
+       $ENV{INTERPRETER} = PerlApp::exe();
+       if (PerlApp::exe() =~ /wxstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Wx';
+       }
 
-	if (PerlApp::exe() =~ /vxstart\.exe$/i) {
-		$ENV{OPENKORE_DEFAULT_INTERFACE} = 'Vx';
-	}
+       if (PerlApp::exe() =~ /vxstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Vx';
+       }
 
-	if (PerlApp::exe() =~ /winguistart\.exe$/i) {
-		$ENV{OPENKORE_DEFAULT_INTERFACE} = 'Win32';
-	}
+       if (PerlApp::exe() =~ /winguistart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Win32';
+       }
 
-	if (PerlApp::exe() =~ /tkstart\.exe$/i) {
-		$ENV{OPENKORE_DEFAULT_INTERFACE} = 'Tk';
-	}
+       if (PerlApp::exe() =~ /tkstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Tk';
+       }
 
+} elsif (defined $ENV{PAR_PROGNAME}) {
+       $ENV{INTERPRETER} = $ENV{PAR_PROGNAME};
+       if ($ENV{PAR_PROGNAME} =~ /wxstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Wx';
+       }
+
+       if ($ENV{PAR_PROGNAME} =~ /vxstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Vx';
+       }
+
+       if ($ENV{PAR_PROGNAME} =~ /winguistart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Win32';
+       }
+
+       if ($ENV{PAR_PROGNAME} =~ /tkstart\.exe$/i) {
+               $ENV{OPENKORE_DEFAULT_INTERFACE} = 'Tk';
+       }
 
 } else {
-	print "Do not run start.pl directly! If you're using Perl then run openkore.pl instead!\n";
-	<STDIN>;
-	exit 1;
+       print "Do not run start.pl directly! If you're using Perl then run openkore.pl instead!\n";
+       <STDIN>;
+       exit 1;
 }
 
 my $file = "openkore.pl";


### PR DESCRIPTION
## Summary
- switch build scripts to `pp` from PAR::Packer
- adjust `start.pl` to work when packed with `pp`

## Testing
- `perl -c start.pl`


------
https://chatgpt.com/codex/tasks/task_e_685076c88d6483258b28e7da6083c6a0